### PR TITLE
Assegnato un nuovo spreasheet ad ogni nuovo utente

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 __pycache__/
 data/credentials.json
+data/sharelist.txt

--- a/ExperienceSampling/App.py
+++ b/ExperienceSampling/App.py
@@ -17,9 +17,6 @@ class App(QApplication):
 
         self.debug = debug
 
-        if checkCredentials():
-            self.spreadSheetWriter = SpreadSheetWriterClass()
-
         QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)   # HiDPI support
         MSWindowsFix()  # MS Windows taskbar fix
 
@@ -45,6 +42,9 @@ class App(QApplication):
         self.postponeTimer.timeout.connect(self.notification.show)
 
         self.startPollTimer()
+
+        if checkCredentials():
+            self.spreadSheetWriter = SpreadSheetWriterClass()
 
     def minutes(self):
         if self.debug==True:

--- a/ExperienceSampling/SpreadSheetWriter.py
+++ b/ExperienceSampling/SpreadSheetWriter.py
@@ -1,4 +1,4 @@
-import gspread
+import gspread, time
 from oauth2client.service_account import ServiceAccountCredentials
 import ExperienceSampling.Utility as ut
 import sys, csv, shutil, os
@@ -21,9 +21,16 @@ class SpreadSheetWriterClass:
 
     def setSheet(self):
         try:
-            sh = self.gc.open('dati_experience')
+            sh = self.gc.open(ut.getID())
             # Open a worksheet from spreadsheet with one shot
             self.worksheet = sh.get_worksheet(0)
+        except gspread.SpreadsheetNotFound:
+            sh = self.gc.create(ut.getID())
+            time.sleep(3)
+            if ut.checkSharelist():
+                [sh.share(email, perm_type='user', role='writer') for email in ut.sharelist()]
+            self.worksheet = sh.get_worksheet(0)
+            self.worksheet.append_row(['Timestamp', 'Activity', 'Valence', 'Arousal', 'Status', 'Notes'],"RAW")
         except:
             return False
 

--- a/ExperienceSampling/SpreadSheetWriter.py
+++ b/ExperienceSampling/SpreadSheetWriter.py
@@ -30,7 +30,7 @@ class SpreadSheetWriterClass:
                 for email in ut.sharelist():
                     self.tryShare(sh,email)
             self.worksheet = sh.get_worksheet(0)
-            #self.worksheet.append_row(['Timestamp', 'Activity', 'Valence', 'Arousal', 'Status', 'Notes'],"RAW")
+            self.worksheet.append_row(['Timestamp', 'Activity', 'Valence', 'Arousal', 'Status', 'Notes'],"RAW")
         except:
             return False
 

--- a/ExperienceSampling/Utility.py
+++ b/ExperienceSampling/Utility.py
@@ -68,6 +68,7 @@ def getID():
         with open(os.path.join(csvDirPath(), 'id'), 'r') as file:
             return file.read()
     else:
+        csvDirCheck()
         id = getLogin() + ":" + str(uuid.uuid4())
         with open(os.path.join(csvDirPath(), 'id'), 'w') as file:
             file.write(id)

--- a/ExperienceSampling/Utility.py
+++ b/ExperienceSampling/Utility.py
@@ -59,13 +59,16 @@ def internet_on():
     except:
         return False
 
+def getLogin():
+    return getpass.getuser() + "@" + socket.gethostname()
+
 def getID():
     """ Returns an unique user/machine identifier """
     if os.path.exists(os.path.join(csvDirPath(), 'id')):
         with open(os.path.join(csvDirPath(), 'id'), 'r') as file:
             return file.read()
     else:
-        id = getpass.getuser() + "@" + socket.gethostname() + "-" + str(uuid.uuid4())
+        id = getLogin() + ":" + str(uuid.uuid4())
         with open(os.path.join(csvDirPath(), 'id'), 'w') as file:
             file.write(id)
         return id

--- a/ExperienceSampling/Utility.py
+++ b/ExperienceSampling/Utility.py
@@ -76,6 +76,13 @@ def toCommitPath():
 def toCommitCheck():
     return os.path.exists(toCommitPath())
 
-
 def checkCredentials():
     return os.path.exists(resource_path('data/credentials.json'))
+
+def checkSharelist():
+    return os.path.exists(resource_path('data/sharelist.txt'))
+
+def sharelist():
+    with open(resource_path('data/sharelist.txt'), 'r') as f:
+        x = f.read().splitlines()
+    return x


### PR DESCRIPTION
closes #7 

Non sono totalmente soddisfatto, dacci un'occhiata tu @Arkango 

Ho scoperto che il bug di gspread che sposta ogni nuova riga più a destra è legato alla presenza di celle vuote tra le righe da aggiungere. Tuttavia pare che il problema non compaia se la prima riga del worksheet non contiene celle vuote. Per questo motivo, come workaround, ho aggiunto la riga:
```
self.worksheet.append_row(['Timestamp', 'Activity', 'Valence', 'Arousal', 'Status', 'Notes'],"RAW")
```

C'è anche un altro bug che impedisce di condividere lo spreadsheet se lo si fa subito dopo la creazione del file. Ho provato ad aggiungere una funzione che aspetta che il file sia effettivamente creato, ma niente.
Come workaround ho aggiunto una sleep() di qualche secondo.

Ad ogni modo, lo spreadsheet viene condiviso con le mail che si trovano nel file `data/sharelist.txt`. Le mail devono essere inserite una per ogni riga.
